### PR TITLE
chore: set up Python using the version specified in `pyproject.toml`.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,10 +14,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: "pyproject.toml"
       - name: Install uv
         uses: astral-sh/setup-uv@v6
-      - name: Install Python 3.12
-        run: uv python install 3.12
       - name: Build
         run: uv build
       - name: Local smoke test (wheel)


### PR DESCRIPTION
@saichandrapandraju no need to review but FYI here's a better way to avoid hardcoding the Python version.