### PR TITLE
refactor: lazy-initialize KFP client in RagasEvaluatorRemote.

### DIFF
--- a/src/llama_stack_provider_ragas/remote/ragas_remote_eval.py
+++ b/src/llama_stack_provider_ragas/remote/ragas_remote_eval.py
@@ -105,7 +105,7 @@ class RagasEvaluatorRemote(Eval, BenchmarksProtocolPrivate):
                 raise RagasEvaluationError(
                     "Failed to initialize Kubeflow Pipelines client."
                 ) from e
-        
+
         return self._kfp_client
 
     def _get_token(self) -> str:


### PR DESCRIPTION
## Summary by Sourcery

Defer creation of the Kubeflow Pipelines client until first use by moving its initialization into a lazy-loading property

Enhancements:
- Introduce kfp_client property for on-demand initialization of the KFP client
- Remove eager import and client setup from the constructor and replace it with a cached private attribute