### PR TITLE
chore: bump version to 0.3.3 and update pyarrow dependency to >=21.0.0 in pyproject.toml and uv.lock 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "pandas<2.3.0",
     "pyarrow>=21.0.0",
     "requests==2.32.4",
+    "datasets>=2.16.0",
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -92,7 +92,6 @@ aiohttp==3.12.15 \
     --hash=sha256:fd736ed420f4db2b8148b52b46b88ed038d0354255f9a73196b7bbce3ea97545 \
     --hash=sha256:fe086edf38b2222328cdf89af0dde2439ee173b8ad7cb659b4e4c6f385b2be3d
     # via
-    #   datasets
     #   fsspec
     #   langchain-community
     #   llama-stack
@@ -418,10 +417,12 @@ dataclasses-json==0.6.7 \
     --hash=sha256:0dbf33f26c8d5305befd61b39d2b3414e8a407bedc2834dea9b8d642666fb40a \
     --hash=sha256:b6b3e528266ea45b9535223bc53ca645f5208833c29229e847b3f26a1cc55fc0
     # via langchain-community
-datasets==2.14.4 \
-    --hash=sha256:29336bd316a7d827ccd4da2236596279b20ca2ac78f64c04c9483da7cbc2459b \
-    --hash=sha256:ef29c2b5841de488cd343cfc26ab979bff77efa4d2285af51f1ad7db5c46a83b
-    # via ragas
+datasets==4.2.0 \
+    --hash=sha256:8333a7db9f3bb8044c1b819a35d4e3e2809596c837793b0921382efffdc36e78 \
+    --hash=sha256:fdc43aaf4a73b31f64f80f72f195ab413a1141ed15555d675b2fd17926f8b026
+    # via
+    #   llama-stack-provider-ragas (pyproject.toml)
+    #   ragas
 dill==0.3.7 \
     --hash=sha256:76b122c08ef4ce2eedcd4d1abd8e641114bfc6c2867f49f3c41facf65bf19f5e \
     --hash=sha256:cc1c8b182eb3013e24bd475ff2e9295af86c1a38eb1aff128dac8962a9ce3c03
@@ -449,7 +450,9 @@ fastapi==0.116.1 \
 filelock==3.19.1 \
     --hash=sha256:66eda1888b0171c998b35be2bcc0f6d75c388a7ce20c3f3f37aa8e96c2dddf58 \
     --hash=sha256:d38e30481def20772f5baf097c122c3babc4fcdb7e14e57049eb9d88c6dc017d
-    # via huggingface-hub
+    # via
+    #   datasets
+    #   huggingface-hub
 fire==0.7.1 \
     --hash=sha256:3b208f05c736de98fb343310d090dcc4d8c78b2a89ea4f32b837c586270a9cbf \
     --hash=sha256:e43fd8a5033a9001e7e2973bab96070694b9f12f2e0ecf96d4683971b5ab1882
@@ -657,6 +660,7 @@ httpx==0.28.1 \
     --hash=sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc \
     --hash=sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad
     # via
+    #   datasets
     #   langsmith
     #   llama-stack
     #   llama-stack-client

--- a/uv.lock
+++ b/uv.lock
@@ -492,12 +492,13 @@ wheels = [
 
 [[package]]
 name = "datasets"
-version = "2.14.4"
+version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiohttp" },
     { name = "dill" },
+    { name = "filelock" },
     { name = "fsspec", extra = ["http"] },
+    { name = "httpx" },
     { name = "huggingface-hub" },
     { name = "multiprocess" },
     { name = "numpy" },
@@ -509,9 +510,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "xxhash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1d/69/8cc725b5d38968fd118e4ce56a483b16e75b7793854c1a392ec4a34eeb31/datasets-2.14.4.tar.gz", hash = "sha256:ef29c2b5841de488cd343cfc26ab979bff77efa4d2285af51f1ad7db5c46a83b", size = 2178719, upload-time = "2023-08-08T15:45:43.015Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/70/48/0186fbc4b86a4f9ecaf04eb01e877e78b53bfa0b03be9c84b2298431ba33/datasets-4.2.0.tar.gz", hash = "sha256:8333a7db9f3bb8044c1b819a35d4e3e2809596c837793b0921382efffdc36e78", size = 582256, upload-time = "2025-10-09T16:10:15.534Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/66/f8/38298237d18d4b6a8ee5dfe390e97bed5adb8e01ec6f9680c0ddf3066728/datasets-2.14.4-py3-none-any.whl", hash = "sha256:29336bd316a7d827ccd4da2236596279b20ca2ac78f64c04c9483da7cbc2459b", size = 519335, upload-time = "2023-08-08T15:45:38.837Z" },
+    { url = "https://files.pythonhosted.org/packages/91/9e/0bbbd09b116fd8ee2d3617e28e6598551d2f0f24d3a2ce99cc87ec85aeb0/datasets-4.2.0-py3-none-any.whl", hash = "sha256:fdc43aaf4a73b31f64f80f72f195ab413a1141ed15555d675b2fd17926f8b026", size = 506316, upload-time = "2025-10-09T16:10:13.375Z" },
 ]
 
 [[package]]
@@ -1465,6 +1466,7 @@ name = "llama-stack-provider-ragas"
 version = "0.3.3"
 source = { editable = "." }
 dependencies = [
+    { name = "datasets" },
     { name = "greenlet" },
     { name = "llama-stack" },
     { name = "pandas" },
@@ -1511,6 +1513,7 @@ remote = [
 [package.metadata]
 requires-dist = [
     { name = "aiosqlite", marker = "extra == 'distro'" },
+    { name = "datasets", specifier = ">=2.16.0" },
     { name = "greenlet", specifier = "==3.2.4" },
     { name = "ipykernel", marker = "extra == 'dev'" },
     { name = "kfp", marker = "extra == 'remote'", specifier = ">=2.5.0" },


### PR DESCRIPTION
## Summary by Sourcery

Bump the provider version to 0.3.3, relax the pyarrow constraint, and refresh pinned versions for key dependencies in requirements and lock files

Enhancements:
- Relax pyarrow version from ==20.0.0 to >=21.0.0 in pyproject.toml
- Upgrade datasets constraint to >=2.16.0 in pyproject.toml
- Update pinned versions of datasets (4.2.0), pandas (2.2.3) and pyarrow (21.0.0) in requirements.txt

Build:
- Bump project version to 0.3.3

Chores:
- Refresh uv.lock to reflect updated dependency pins