### PR TITLE
Remove repository URL from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ dependencies = [
 
 [project.urls]
 homepage = "https://github.com/trustyai-explainability/llama-stack-provider-ragas"
-repository = "https://github.com/trustyai-explainability/llama-stack-provider-ragas"
 
 [project.optional-dependencies]
 remote = ["kfp>=2.5.0", "kfp-kubernetes>=2.0.0", "s3fs>=2024.12.0", "kubernetes>=30.0.0"]


### PR DESCRIPTION
Avoid Python's 3.12 tomllib from complaining about 2 urls: `tomllib.TOMLDecodeError: Cannot declare ('project', 'urls') twice (at line 41, column 14)`