### PR TITLE
Revert "Remove repository URL from pyproject.toml"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
 
 [project.urls]
 homepage = "https://github.com/trustyai-explainability/llama-stack-provider-ragas"
+repository = "https://github.com/trustyai-explainability/llama-stack-provider-ragas"
 
 [project.optional-dependencies]
 remote = ["kfp>=2.5.0", "kfp-kubernetes>=2.0.0", "s3fs>=2024.12.0", "kubernetes>=30.0.0"]


### PR DESCRIPTION
This reverts commit f88616ea95fd2c0a26f5a517c13b85dc33e9c6c2.

Incorrect fix, the issue was a duplication from a merge downstream, not a tomllib issue.