### PR TITLE
chore: update demo notebook to use 3.0 evals

### DIFF
--- a/demos/basic_demo.ipynb
+++ b/demos/basic_demo.ipynb
@@ -456,7 +456,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -581,7 +581,7 @@
     "# since we can't set the embedding model in the benchmark config,\n",
     "# the embedding model is set in the distribution run.yaml file(all-MiniLM-L6-v2)\n",
     "\n",
-    "remote_job = client.eval.run_eval(\n",
+    "remote_job = client.alpha.eval.run_eval(\n",
     "    benchmark_id=\"ragas_demo_benchmark__remote\",\n",
     "    benchmark_config={\n",
     "        \"eval_candidate\": {\n",
@@ -598,7 +598,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -655,7 +655,7 @@
     "# since we can't set the embedding model in the benchmark config,\n",
     "# the embedding model is set in the distribution run.yaml file(all-MiniLM-L6-v2)\n",
     "\n",
-    "inline_job = client.eval.run_eval(\n",
+    "inline_job = client.alpha.eval.run_eval(\n",
     "    benchmark_id=\"ragas_demo_benchmark__inline\",\n",
     "    benchmark_config={\n",
     "        \"eval_candidate\": {\n",
@@ -679,7 +679,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -804,7 +804,7 @@
    "source": [
     "# wait a bit for the job to complete\n",
     "pprint(\n",
-    "    client.eval.jobs.status(\n",
+    "    client.alpha.eval.jobs.status(\n",
     "        benchmark_id=\"ragas_demo_benchmark__inline\", job_id=inline_job.job_id\n",
     "    )\n",
     ")"
@@ -812,7 +812,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -935,7 +935,7 @@
    "source": [
     "# wait a bit for the job to complete\n",
     "pprint(\n",
-    "    client.eval.jobs.status(\n",
+    "    client.alpha.eval.jobs.status(\n",
     "        benchmark_id=\"ragas_demo_benchmark__remote\", job_id=remote_job.job_id\n",
     "    )\n",
     ")"
@@ -943,7 +943,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -1040,7 +1040,7 @@
     }
    ],
    "source": [
-    "remote_results = client.eval.jobs.retrieve(\n",
+    "remote_results = client.alpha.eval.jobs.retrieve(\n",
     "    benchmark_id=\"ragas_demo_benchmark__remote\", job_id=remote_job.job_id\n",
     ")\n",
     "pprint(remote_results)"
@@ -1048,7 +1048,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -1143,7 +1143,7 @@
     }
    ],
    "source": [
-    "inline_results = client.eval.jobs.retrieve(\n",
+    "inline_results = client.alpha.eval.jobs.retrieve(\n",
     "    benchmark_id=\"ragas_demo_benchmark__inline\", job_id=inline_job.job_id\n",
     ")\n",
     "pprint(inline_results)"


### PR DESCRIPTION
For 3.0 evals have been slated as [alpha](https://github.com/llamastack/llama-stack/blob/658fb2c777c26c1e127407bf3cd2e48a8d90f2f0/client-sdks/stainless/openapi.stainless.yml#L449-L465) with this the way we call evals needs to be updated. 

Testing conditions:
Run the notebook with a 3.0 version of Llama Stack

## Summary by Sourcery

Update the basic demo notebook to use the new alpha eval API namespace and clear execution counts