### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,17 @@
+# Default owners for everything in the repo
+* @dmaniloff @ruivieira @Bobbins228
+
+# Source code
+/src/ @dmaniloff @ruivieira @Bobbins228
+
+# Tests
+/tests/ @dmaniloff @ruivieira @Bobbins228
+
+# CI/CD and GitHub configuration
+/.github/ @dmaniloff
+
+# Documentation
+/docs/ @dmaniloff @ruivieira
+
+# Distribution configuration
+/distribution/ @dmaniloff


### PR DESCRIPTION
## Summary
- Adds `.github/CODEOWNERS` to enable automated PR review assignment
- Maps repo directories to key maintainers based on git contribution history

## Test plan
- [ ] Verify CODEOWNERS syntax is valid
- [ ] Confirm GitHub recognizes the file and suggests reviewers on new PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Chores:
- Introduce repository-wide CODEOWNERS configuration for automated reviewer assignment on pull requests.