### PR TITLE
Set repository to maintenance mode for llama-stack 0.6.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,8 +65,7 @@ jobs:
       matrix:
         python-version: ["3.12"]
         llama-stack-version:
-          - "main"
-          - "0.5.0"
+          - "0.6.0"
 
     steps:
     - name: Checkout code
@@ -98,13 +97,8 @@ jobs:
 
     - name: Install llama-stack version
       run: |
-        if [ "${{ matrix.llama-stack-version }}" = "main" ]; then
-          uv pip install "llama-stack @ git+https://github.com/llamastack/llama-stack.git@main"
-          uv pip install "llama-stack-api @ git+https://github.com/llamastack/llama-stack.git@main#subdirectory=src/llama_stack_api"
-        else
-          uv pip install "llama-stack==${{ matrix.llama-stack-version }}"
-          uv pip install "llama-stack-api==${{ matrix.llama-stack-version }}"
-        fi
+        uv pip install "llama-stack==${{ matrix.llama-stack-version }}"
+        uv pip install "llama-stack-api==${{ matrix.llama-stack-version }}"
 
     - name: Run integration tests
       run: |

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -16,13 +16,13 @@ branches are organized by llama-stack compatibility:
 | `release/0.4.x`  | 0.3.x              | 0.4.3+            |
 | `release/0.5.x`  | 0.4.x              | 0.5.4+            |
 | `release/0.6.x`  | 0.5.x              | 0.6.0+            |
-| `main`           | 0.6.x+             | 0.7.0+            |
+| `main`           | 0.6.x              | 0.7.0+            |
 
 ## Version Compatibility Table
 
 | Provider Version | Llama-Stack Dependency        | Python  | Release Branch   | Notes                                |
 |------------------|-------------------------------|---------|------------------|--------------------------------------|
-| 0.7.0            | >=0.6.0                       | >=3.12  | `main`           | Current latest release               |
+| 0.7.0            | >=0.6.0,<0.7.0                | >=3.12  | `main`           | Maintenance mode — final release     |
 | 0.6.1            | >=0.5.0                       | >=3.12  | `release/0.6.x`  | Maintenance release for lls 0.5.x    |
 | 0.5.4            | [client]>=0.4.2,<0.5.0        | >=3.12  | `release/0.5.x`  | Maintenance release for lls 0.4.x   |
 | 0.4.3            | [client]>=0.3.5,<0.4.0        | >=3.12  | `release/0.4.x`  | Maintenance release for lls 0.3.x   |

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 [![PyPI version](https://img.shields.io/pypi/v/llama_stack_provider_ragas.svg)](https://pypi.org/project/llama-stack-provider-ragas/)
 
 
+> **Maintenance Mode**: This repository is in maintenance mode. Provider version 0.7.0 targeting llama-stack 0.6.x is the final release. Only critical bug fixes will be accepted. No new features or support for newer llama-stack versions are planned.
+
 ## About
 This repository implements [Ragas](https://github.com/explodinggradients/ragas) as an out-of-tree [Llama Stack](https://github.com/meta-llama/llama-stack) evaluation provider.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,15 +25,15 @@ authors = [
 keywords = ["llama-stack", "ragas", "evaluation"]
 dependencies = [
     "setuptools-scm",
-    "llama-stack>=0.6.0",
-    "llama-stack-api>=0.6.0",
+    "llama-stack>=0.6.0,<0.7.0",
+    "llama-stack-api>=0.6.0,<0.7.0",
     "greenlet==3.2.4", # inline/files/localfs errors saying greenlet not found
     "ragas>=0.4.0,<0.5.0",
     "pandas<2.4.0",
     "pyarrow>=21.0.0",
     "requests>=2.32.5",
     "datasets>=2.16.0",
-    "llama-stack-client>=0.6.0",
+    "llama-stack-client>=0.6.0,<0.7.0",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -1571,7 +1571,7 @@ wheels = [
 
 [[package]]
 name = "llama-stack"
-version = "0.7.1"
+version = "0.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1602,21 +1602,20 @@ dependencies = [
     { name = "rich" },
     { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "starlette" },
-    { name = "structlog" },
     { name = "termcolor" },
     { name = "tiktoken" },
     { name = "tornado" },
     { name = "urllib3" },
     { name = "uvicorn" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/84/9b/a8577f0761b02be4d45d625cf5870ab64859dbbe219088d6c8a39e9cb79d/llama_stack-0.7.1.tar.gz", hash = "sha256:d88dc8430abe1d26f3908ab506f0f6ccd4f3c16ba06ee46ac662f4c896c52da8", size = 15857581, upload-time = "2026-04-08T14:21:12.036Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/58/faa1a08dc0113ffbf3f6c1822ef65014b3b6a98fe3f7cbfd5067deb7557e/llama_stack-0.6.1.tar.gz", hash = "sha256:32cce3bc0f40a8762dac290da697765a7e0b06eb5e76828ee4fe713636ab1da3", size = 13643536, upload-time = "2026-03-30T13:13:03.449Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/41/f57aedebba533bf5e8b7c5f3f2ee1edb88409e1aa5c83fa7ddc5f85b3c48/llama_stack-0.7.1-py3-none-any.whl", hash = "sha256:65b9c827989011af3879ad051db9134163f8e6b3bc3685340328f21f5d07cf5f", size = 782710, upload-time = "2026-04-08T14:21:10.031Z" },
+    { url = "https://files.pythonhosted.org/packages/46/e1/613870660d7454d247d655604e58b6280181adc987b9694435f61ec957cd/llama_stack-0.6.1-py3-none-any.whl", hash = "sha256:a03c4452e8a6f54047b1f30f860172050aecbbe9c979b35b167b423131a71c4d", size = 771006, upload-time = "2026-03-30T13:13:01.481Z" },
 ]
 
 [[package]]
 name = "llama-stack-api"
-version = "0.7.1"
+version = "0.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fastapi" },
@@ -1626,14 +1625,14 @@ dependencies = [
     { name = "opentelemetry-sdk" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f3/d0/a320b11eec0db00c05ad22525f5ef8825b512215d7d138964caddb50dea2/llama_stack_api-0.7.1.tar.gz", hash = "sha256:441b0e1c29f7acc0a1d9b697d276f2c352387b719b67926af9983caec95f107e", size = 135479, upload-time = "2026-04-08T14:20:31.64Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/0e/0783e307c073bcf867f297dd87c7182525f4afd622e17283d30540c7f741/llama_stack_api-0.6.1.tar.gz", hash = "sha256:924c6faddc01ffc2124eaa20d876fac52f6dc98cc7968b6643b880c4f10254f9", size = 136416, upload-time = "2026-03-30T13:12:28.122Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e7/0b/0ca3d5cc63bdd51327a051907e97916232dfa786d7758cec989277dbec19/llama_stack_api-0.7.1-py3-none-any.whl", hash = "sha256:13467639f83ffc87b950513afd2270e6ce0403852442d6214f3f08c087a2d5d5", size = 159662, upload-time = "2026-04-08T14:20:30.351Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/5b/ef2b8dcfb4f1338e16ab8f4f0fa1af77db67f3a3e90a28555f35dbcdd541/llama_stack_api-0.6.1-py3-none-any.whl", hash = "sha256:b2068dffac4ad32a6766a867dedb38f17bd1ae5af408db7a5e13cbd3bb3940a2", size = 161070, upload-time = "2026-03-30T13:12:26.748Z" },
 ]
 
 [[package]]
 name = "llama-stack-client"
-version = "0.7.2"
+version = "0.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1652,9 +1651,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d7/3d/c4a268a4b60feb6f7e6da3fad2504aa157a52384529766560f8f3cfca43f/llama_stack_client-0.7.2.tar.gz", hash = "sha256:0e3458800af6a18fd8fc5e0760ed626931a416f6c1fdf24aeba4001e6fca9aec", size = 372953, upload-time = "2026-04-08T14:19:32.02Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/01/47b32f2fb003b7f3fc24a401cd7b091892025f626dd07661647f64e3df68/llama_stack_client-0.6.1.tar.gz", hash = "sha256:13dabd74c29d5159cdcfca5a9e6f99c99f08aa688fa8403d6c5f6042b61519d2", size = 368690, upload-time = "2026-03-30T13:11:39.597Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/a8/cc7fa209471abcaac51139b3e6655c3b18ea718f0afa7cfa6ad974dd9eab/llama_stack_client-0.7.2-py3-none-any.whl", hash = "sha256:8b86156f2522c241ae46280e59287b7716c3cdaf016b6477630eb64bd8cbf150", size = 375337, upload-time = "2026-04-08T14:19:30.444Z" },
+    { url = "https://files.pythonhosted.org/packages/57/bd/da2f43993b9b753f0465548b17efbbee492a6980fdd5e14fadf8566cdb1f/llama_stack_client-0.6.1-py3-none-any.whl", hash = "sha256:47aa4f47b591ffbd35b7be946552c4198006daaf57505898372d7bc7c1df510f", size = 391998, upload-time = "2026-03-30T13:11:38.067Z" },
 ]
 
 [[package]]
@@ -1723,9 +1722,9 @@ requires-dist = [
     { name = "kfp-pipeline-spec", marker = "extra == 'remote'", specifier = ">=2.0.0" },
     { name = "kfp-server-api", marker = "extra == 'remote'", specifier = ">=2.0.0" },
     { name = "kubernetes", marker = "extra == 'remote'", specifier = ">=30.0.0" },
-    { name = "llama-stack", specifier = ">=0.6.0" },
-    { name = "llama-stack-api", specifier = ">=0.6.0" },
-    { name = "llama-stack-client", specifier = ">=0.6.0" },
+    { name = "llama-stack", specifier = ">=0.6.0,<0.7.0" },
+    { name = "llama-stack-api", specifier = ">=0.6.0,<0.7.0" },
+    { name = "llama-stack-client", specifier = ">=0.6.0,<0.7.0" },
     { name = "llama-stack-provider-ragas", extras = ["distro"], marker = "extra == 'dev'" },
     { name = "llama-stack-provider-ragas", extras = ["remote"], marker = "extra == 'dev'" },
     { name = "mypy", marker = "extra == 'dev'" },
@@ -3456,15 +3455,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ba/b8/73a0e6a6e079a9d9cfa64113d771e421640b6f679a52eeb9b32f72d871a1/starlette-0.50.0.tar.gz", hash = "sha256:a2a17b22203254bcbc2e1f926d2d55f3f9497f769416b3190768befe598fa3ca", size = 2646985, upload-time = "2025-11-01T15:25:27.516Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d9/52/1064f510b141bd54025f9b55105e26d1fa970b9be67ad766380a3c9b74b0/starlette-0.50.0-py3-none-any.whl", hash = "sha256:9e5391843ec9b6e472eed1365a78c8098cfceb7a74bfd4d6b1c0c0095efb3bca", size = 74033, upload-time = "2025-11-01T15:25:25.461Z" },
-]
-
-[[package]]
-name = "structlog"
-version = "25.5.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ef/52/9ba0f43b686e7f3ddfeaa78ac3af750292662284b3661e91ad5494f21dbc/structlog-25.5.0.tar.gz", hash = "sha256:098522a3bebed9153d4570c6d0288abf80a031dfdb2048d59a49e9dc2190fc98", size = 1460830, upload-time = "2025-10-27T08:28:23.028Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/45/a132b9074aa18e799b891b91ad72133c98d8042c70f6240e4c5f9dabee2f/structlog-25.5.0-py3-none-any.whl", hash = "sha256:a8453e9b9e636ec59bd9e79bbd4a72f025981b3ba0f5837aebf48f02f37a7f9f", size = 72510, upload-time = "2025-10-27T08:28:21.535Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Cap `llama-stack`, `llama-stack-api`, and `llama-stack-client` dependencies at `<0.7.0`
- CI matrix: test only against `0.6.0` (removed `main`)
- Update COMPATIBILITY.md to reflect final release status
- Add maintenance mode notice to README.md

Provider version 0.7.0 targeting llama-stack 0.6.x is the final release. Only critical bug fixes will be accepted.

## Test plan
- [x] CI passes with updated matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)